### PR TITLE
Vehicle lighting

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,6 +60,7 @@ add_executable(RCCar
     WayWise/sensors/imu/bno055orientationupdater.cpp
     WayWise/sensors/imu/imuorientationupdater.cpp
     WayWise/vehicles/carstate.cpp
+    WayWise/vehicles/vehiclelighting.cpp
     WayWise/vehicles/controller/carmovementcontroller.cpp
     WayWise/vehicles/controller/motorcontroller.h
     WayWise/vehicles/controller/movementcontroller.cpp
@@ -77,4 +78,5 @@ target_link_libraries(RCCar
     PRIVATE Qt5::Network
     PRIVATE Qt5::SerialPort
     PRIVATE MAVSDK::mavsdk
+    PRIVATE gpiodcxx
 )

--- a/main.cpp
+++ b/main.cpp
@@ -19,6 +19,7 @@
 #include "WayWise/communication/mavsdkvehicleserver.h"
 #include "WayWise/communication/parameterserver.h"
 #include "WayWise/logger/logger.h"
+#include "WayWise/vehicles/vehiclelighting.h"
 
 static void terminationSignalHandler(int signal) {
     qDebug() << "Shutting down";
@@ -152,12 +153,14 @@ int main(int argc, char *argv[])
     QObject::connect(mWaypointFollower.get(), &WaypointFollower::activateEmergencyBrake, &mEmergencyBrake, &EmergencyBrake::activateEmergencyBrake);
     QObject::connect(&mEmergencyBrake, &EmergencyBrake::emergencyBrake, mWaypointFollower.get(), &WaypointFollower::stop);
 
+    // Vehicle lighting
+    QSharedPointer<VehicleLighting> mVehicleLighting(new VehicleLighting(mCarState));
+
     // Setup MAVLINK communication towards ControlTower
     mavsdkVehicleServer.setMovementController(mCarMovementController);
     mavsdkVehicleServer.setUbloxRover(mUbloxRover);
     mavsdkVehicleServer.setWaypointFollower(mWaypointFollower);
     // TODO: motor controller status not supported in ControlTower
-//    QObject::connect(mVESCMotorController.get(), &VESCMotorController::gotStatusValues, &mPacketIFServer, &PacketInterfaceTCPServer::updateMotorControllerStatus);
 
     // Watchdog that warns when EventLoop is slowed down
     SimpleWatchdog watchdog;


### PR DESCRIPTION
Adds vehicle lighting functionality.

$ sudo apt install gpiod

To verify that GPIO pins is activated, run following: 
![Screenshot from 2023-12-14 12-03-31](https://github.com/RISE-Dependable-Transport-Systems/RCCar/assets/76961018/b2542c51-b7d8-40f2-88a2-2e907ef804af)


If GPIO chip is unavailable, qDebug will print an error, and RCCar will work without lighting as before. 